### PR TITLE
Dependent types

### DIFF
--- a/bin/assign-all-permissions-to-user
+++ b/bin/assign-all-permissions-to-user
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
 
+/**
+ * This script assigns all available permissions to user given as argument.
+ *
+ * Useful in development.
+ */
+
 const {SQL} = require('sql-template-strings');
 const db = require('../db');
 

--- a/bin/create-all-permissions
+++ b/bin/create-all-permissions
@@ -1,15 +1,23 @@
 #!/usr/bin/env node
 
+/**
+ * This script creates all possible permissions. Every permission can then be assigned
+ * to some user via `assign-all-permissions` script.
+ *
+ * Useful in development.
+ */
+
 const _ = require('lodash/fp');
-const plan = require('../modules/rest/plan');
-const uuid = require('../uuid');
+require('../src/applications/index');
+const getPlan = require('../src/applications/plan').get;
+const uuid = require('../src/uuid');
 const qb = require('@imatic/pgqb');
-const db = require('../db');
+const db = require('../src/db');
 
 db.init();
 
 const permissions = ['view', 'create', 'update', 'delete'];
-const types = _.flatMap(_.keys, plan);
+const types = _.flatMap(_.keys, getPlan());
 
 const columns = ['key', 'resourceType', 'permission'];
 

--- a/bin/create-token
+++ b/bin/create-token
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
 
+/**
+ * This script creates token for user.
+ *
+ * Useful in development.
+ */
+
 const jwt = require('jsonwebtoken');
 const config = require('../config');
 

--- a/bin/hash-password
+++ b/bin/hash-password
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
 
+/**
+ * This script hashes given password.
+ *
+ * Useful in development.
+ */
+
 const security = require('../security');
 
 if (process.argv.length !== 3) {

--- a/bin/load-fixtures
+++ b/bin/load-fixtures
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
 
+/**
+ * This script loads fixtures.
+ *
+ * Useful in development.
+ */
+
 const {spawn} = require('child_process');
 const {pgConfig} = require('../config');
 

--- a/bin/migrate
+++ b/bin/migrate
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
 
+/**
+ * This scrip sets db to given version and then runs migration scripts do/undo to get there.
+ * Without argument, it runs all migrations.
+ *
+ * In production, this script should be always run without arguments to prevent data loss.
+ */
+
 const migrations = require('../src/migrations');
 
 const targetVersion = process.argv[2] || 'max';

--- a/bin/migrate
+++ b/bin/migrate
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const migrations = require('../migrations');
+const migrations = require('../src/migrations');
 
 const targetVersion = process.argv[2] || 'max';
 migrations.migrate(targetVersion);

--- a/config.js
+++ b/config.js
@@ -1,9 +1,5 @@
 const ptr4 = {
 	clusterPorts: [9850, 9851, 9852, 9853, 9854, 9855, 9856, 9857, 9858, 9859],
-	jsonWebToken: {
-		string: "57808ccb-b490-44d0-9df9-aa111b56682f",
-		cookieMaxAge: 10000
-	},
 	keepAliveWorkers: true,
 	pgConfig: {
 		normal: {

--- a/fixtures.sql
+++ b/fixtures.sql
@@ -3,7 +3,16 @@ BEGIN;
 -- guest: 52ddabec-d01a-49a0-bb4d-5ff931bd346e
 -- user: e56f3545-57f5-44f9-9094-2750a69ef67e
 
-TRUNCATE "user"."users", "user"."groups", "user"."permissions" CASCADE;
+TRUNCATE
+  "user"."users",
+  "user"."groups",
+  "user"."permissions",
+  "dataSources"."dataSource",
+  "dataSources"."raster",
+  "dataSources"."vector",
+  "dataSources"."wms",
+  "dataSources"."wmts"
+  CASCADE;
 
 INSERT INTO "user"."users"
   ("key", "email", "password", "phone", "name")
@@ -52,6 +61,10 @@ VALUES
   ('913e3bae-e5dd-4600-a854-ca7b65199bbf', null, 'user', 'update'),
   ('9ac648e7-00d0-4196-be44-9ae2d7cfb598', null, 'user', 'delete'),
   ('828af8c1-5438-475b-9f91-af432745e83f', null, 'user', 'view'),
+  ('9d2b52c0-ced8-4a3c-b5ae-ea97befd3305', null, 'dataSource', 'create'),
+  ('2f8f7e58-2c55-4c06-90c6-a5a164c3f1f1', null, 'dataSource', 'update'),
+  ('92901779-f29f-44a3-ab05-2a22b6a94848', null, 'dataSource', 'delete'),
+  ('d116a380-4cf2-4241-9b88-3c0488848a05', null, 'dataSource', 'view'),
   ('f2ead234-6402-4a6e-9374-b243647edc44', '8b162b2f-44ee-47a4-af6c-0bbc882b6bb8', 'user', 'view'),
   ('4f2b3dc7-9b3f-4624-82c0-93d139e19baa', '8b162b2f-44ee-47a4-af6c-0bbc882b6bb8', 'user', 'update'),
   ('e84dfa30-f2fc-4a1f-988c-b7f4e2489f2f', '8b162b2f-44ee-47a4-af6c-0bbc882b6bb8', 'user', 'delete'),
@@ -70,6 +83,14 @@ VALUES
   ('2d069e3a-f77f-4a1f-aeda-50fd06c8c35d', '913e3bae-e5dd-4600-a854-ca7b65199bbf'),
   -- user: admin@example.com             ,  users:delete
   ('2d069e3a-f77f-4a1f-aeda-50fd06c8c35d', '9ac648e7-00d0-4196-be44-9ae2d7cfb598'),
+  -- user: admin@example.com             , dataSource:create
+  ('2d069e3a-f77f-4a1f-aeda-50fd06c8c35d', '9d2b52c0-ced8-4a3c-b5ae-ea97befd3305'),
+  -- user: admin@example.com             , dataSource:update
+  ('2d069e3a-f77f-4a1f-aeda-50fd06c8c35d', '2f8f7e58-2c55-4c06-90c6-a5a164c3f1f1'),
+  -- user: admin@example.com             , dataSource:delete
+  ('2d069e3a-f77f-4a1f-aeda-50fd06c8c35d', '92901779-f29f-44a3-ab05-2a22b6a94848'),
+  -- user: admin@example.com             , dataSource:view
+  ('2d069e3a-f77f-4a1f-aeda-50fd06c8c35d', 'd116a380-4cf2-4241-9b88-3c0488848a05'),
   -- user: specificPermsAdmin@example.com, users[key]:update
   ('39ed471f-8383-4283-bb8a-303cb05cadef', '4f2b3dc7-9b3f-4624-82c0-93d139e19baa'),
   -- user: specificPermsAdmin@example.com, users[key]:delete

--- a/fixtures.sql
+++ b/fixtures.sql
@@ -61,10 +61,10 @@ VALUES
   ('913e3bae-e5dd-4600-a854-ca7b65199bbf', null, 'user', 'update'),
   ('9ac648e7-00d0-4196-be44-9ae2d7cfb598', null, 'user', 'delete'),
   ('828af8c1-5438-475b-9f91-af432745e83f', null, 'user', 'view'),
-  ('9d2b52c0-ced8-4a3c-b5ae-ea97befd3305', null, 'dataSource', 'create'),
-  ('2f8f7e58-2c55-4c06-90c6-a5a164c3f1f1', null, 'dataSource', 'update'),
-  ('92901779-f29f-44a3-ab05-2a22b6a94848', null, 'dataSource', 'delete'),
-  ('d116a380-4cf2-4241-9b88-3c0488848a05', null, 'dataSource', 'view'),
+  ('9d2b52c0-ced8-4a3c-b5ae-ea97befd3305', null, 'spatial', 'create'),
+  ('2f8f7e58-2c55-4c06-90c6-a5a164c3f1f1', null, 'spatial', 'update'),
+  ('92901779-f29f-44a3-ab05-2a22b6a94848', null, 'spatial', 'delete'),
+  ('d116a380-4cf2-4241-9b88-3c0488848a05', null, 'spatial', 'view'),
   ('f2ead234-6402-4a6e-9374-b243647edc44', '8b162b2f-44ee-47a4-af6c-0bbc882b6bb8', 'user', 'view'),
   ('4f2b3dc7-9b3f-4624-82c0-93d139e19baa', '8b162b2f-44ee-47a4-af6c-0bbc882b6bb8', 'user', 'update'),
   ('e84dfa30-f2fc-4a1f-988c-b7f4e2489f2f', '8b162b2f-44ee-47a4-af6c-0bbc882b6bb8', 'user', 'delete'),
@@ -83,13 +83,13 @@ VALUES
   ('2d069e3a-f77f-4a1f-aeda-50fd06c8c35d', '913e3bae-e5dd-4600-a854-ca7b65199bbf'),
   -- user: admin@example.com             ,  users:delete
   ('2d069e3a-f77f-4a1f-aeda-50fd06c8c35d', '9ac648e7-00d0-4196-be44-9ae2d7cfb598'),
-  -- user: admin@example.com             , dataSource:create
+  -- user: admin@example.com             , spatial:create
   ('2d069e3a-f77f-4a1f-aeda-50fd06c8c35d', '9d2b52c0-ced8-4a3c-b5ae-ea97befd3305'),
-  -- user: admin@example.com             , dataSource:update
+  -- user: admin@example.com             , spatial:update
   ('2d069e3a-f77f-4a1f-aeda-50fd06c8c35d', '2f8f7e58-2c55-4c06-90c6-a5a164c3f1f1'),
-  -- user: admin@example.com             , dataSource:delete
+  -- user: admin@example.com             , spatial:delete
   ('2d069e3a-f77f-4a1f-aeda-50fd06c8c35d', '92901779-f29f-44a3-ab05-2a22b6a94848'),
-  -- user: admin@example.com             , dataSource:view
+  -- user: admin@example.com             , spatial:view
   ('2d069e3a-f77f-4a1f-aeda-50fd06c8c35d', 'd116a380-4cf2-4241-9b88-3c0488848a05'),
   -- user: specificPermsAdmin@example.com, users[key]:update
   ('39ed471f-8383-4283-bb8a-303cb05cadef', '4f2b3dc7-9b3f-4624-82c0-93d139e19baa'),

--- a/fixtures.sql
+++ b/fixtures.sql
@@ -51,24 +51,24 @@ VALUES
   ('3e3f4300-1336-4043-baa3-b65a025c2d83', '742b6f3f-a77e-4267-8e96-1e4cea96dec3');
 
 INSERT INTO "user"."permissions"
-  ("key", "resourceKey", "resourceType", "permission")
+  ("key", "resourceKey", "resourceGroup", "resourceType", "permission")
 VALUES
-  ('0da66083-77ad-4e66-9338-0c8344de9eba', null, 'case', 'create'),
-  ('42e8bdf8-19c8-4658-aded-b1c724539072', null, 'case', 'update'),
-  ('820c4a94-9588-4926-8ba0-2df7abe2eb7f', null, 'scope', 'delete'),
-  ('6a7df854-4dc0-4093-b8a0-15e2e0a91ed0', null, 'place', 'delete'),
-  ('6897b1fc-a3e3-4195-a41a-f492d4a9df2a', null, 'user', 'create'),
-  ('913e3bae-e5dd-4600-a854-ca7b65199bbf', null, 'user', 'update'),
-  ('9ac648e7-00d0-4196-be44-9ae2d7cfb598', null, 'user', 'delete'),
-  ('828af8c1-5438-475b-9f91-af432745e83f', null, 'user', 'view'),
-  ('9d2b52c0-ced8-4a3c-b5ae-ea97befd3305', null, 'spatial', 'create'),
-  ('2f8f7e58-2c55-4c06-90c6-a5a164c3f1f1', null, 'spatial', 'update'),
-  ('92901779-f29f-44a3-ab05-2a22b6a94848', null, 'spatial', 'delete'),
-  ('d116a380-4cf2-4241-9b88-3c0488848a05', null, 'spatial', 'view'),
-  ('f2ead234-6402-4a6e-9374-b243647edc44', '8b162b2f-44ee-47a4-af6c-0bbc882b6bb8', 'user', 'view'),
-  ('4f2b3dc7-9b3f-4624-82c0-93d139e19baa', '8b162b2f-44ee-47a4-af6c-0bbc882b6bb8', 'user', 'update'),
-  ('e84dfa30-f2fc-4a1f-988c-b7f4e2489f2f', '8b162b2f-44ee-47a4-af6c-0bbc882b6bb8', 'user', 'delete'),
-  ('432348bc-6adf-4fd3-ac44-48a15f7d8ac6', '7c5acddd-3625-46ef-90b3-82f829afb258', 'user', 'view');
+  ('0da66083-77ad-4e66-9338-0c8344de9eba', null, 'metadata', 'case', 'create'),
+  ('42e8bdf8-19c8-4658-aded-b1c724539072', null, 'metadata', 'case', 'update'),
+  ('820c4a94-9588-4926-8ba0-2df7abe2eb7f', null, 'metadata', 'scope', 'delete'),
+  ('6a7df854-4dc0-4093-b8a0-15e2e0a91ed0', null, 'metadata', 'place', 'delete'),
+  ('6897b1fc-a3e3-4195-a41a-f492d4a9df2a', null, 'user', 'user', 'create'),
+  ('913e3bae-e5dd-4600-a854-ca7b65199bbf', null, 'user', 'user', 'update'),
+  ('9ac648e7-00d0-4196-be44-9ae2d7cfb598', null, 'user', 'user', 'delete'),
+  ('828af8c1-5438-475b-9f91-af432745e83f', null, 'user', 'user', 'view'),
+  ('9d2b52c0-ced8-4a3c-b5ae-ea97befd3305', null, 'dataSources', 'spatial', 'create'),
+  ('2f8f7e58-2c55-4c06-90c6-a5a164c3f1f1', null, 'dataSources', 'spatial', 'update'),
+  ('92901779-f29f-44a3-ab05-2a22b6a94848', null, 'dataSources', 'spatial', 'delete'),
+  ('d116a380-4cf2-4241-9b88-3c0488848a05', null, 'dataSources', 'spatial', 'view'),
+  ('f2ead234-6402-4a6e-9374-b243647edc44', '8b162b2f-44ee-47a4-af6c-0bbc882b6bb8', 'user', 'user', 'view'),
+  ('4f2b3dc7-9b3f-4624-82c0-93d139e19baa', '8b162b2f-44ee-47a4-af6c-0bbc882b6bb8', 'user', 'user', 'update'),
+  ('e84dfa30-f2fc-4a1f-988c-b7f4e2489f2f', '8b162b2f-44ee-47a4-af6c-0bbc882b6bb8', 'user', 'user', 'delete'),
+  ('432348bc-6adf-4fd3-ac44-48a15f7d8ac6', '7c5acddd-3625-46ef-90b3-82f829afb258', 'user', 'user', 'view');
 
 INSERT INTO "user"."userPermissions"
   ("userKey", "permissionKey")

--- a/migrations/202007290846.do.sql
+++ b/migrations/202007290846.do.sql
@@ -1,0 +1,28 @@
+SELECT audit.audit_table('"application"."application"');
+SELECT audit.audit_table('"application"."configuration"');
+SELECT audit.audit_table('"application"."layerTree"');
+
+SELECT audit.audit_table('"dataSources"."attributeDataSource"');
+SELECT audit.audit_table('"dataSources"."dataSource"');
+SELECT audit.audit_table('"dataSources"."raster"');
+SELECT audit.audit_table('"dataSources"."vector"');
+SELECT audit.audit_table('"dataSources"."wms"');
+SELECT audit.audit_table('"dataSources"."wmts"');
+
+SELECT audit.audit_table('"metadata"."areaTree"');
+SELECT audit.audit_table('"metadata"."areaTreeLevel"');
+SELECT audit.audit_table('"metadata"."attribute"');
+SELECT audit.audit_table('"metadata"."attributeSet"');
+SELECT audit.audit_table('"metadata"."case"');
+SELECT audit.audit_table('"metadata"."layerTemplate"');
+SELECT audit.audit_table('"metadata"."period"');
+SELECT audit.audit_table('"metadata"."place"');
+SELECT audit.audit_table('"metadata"."scenario"');
+SELECT audit.audit_table('"metadata"."scope"');
+SELECT audit.audit_table('"metadata"."style"');
+SELECT audit.audit_table('"metadata"."tag"');
+
+SELECT audit.audit_table('"specific"."esponFuoreIndicator"');
+SELECT audit.audit_table('"specific"."lpisChangeCase"');
+
+SELECT audit.audit_table('"views"."view"');

--- a/migrations/202007290846.undo.sql
+++ b/migrations/202007290846.undo.sql
@@ -1,0 +1,52 @@
+DROP TRIGGER audit_trigger_row ON "application"."application";
+DROP TRIGGER audit_trigger_stm ON "application"."application";
+DROP TRIGGER audit_trigger_row ON "application"."configuration";
+DROP TRIGGER audit_trigger_stm ON "application"."configuration";
+DROP TRIGGER audit_trigger_row ON "application"."layerTree";
+DROP TRIGGER audit_trigger_stm ON "application"."layerTree";
+
+DROP TRIGGER audit_trigger_row ON "dataSources"."attributeDataSource";
+DROP TRIGGER audit_trigger_stm ON "dataSources"."attributeDataSource";
+DROP TRIGGER audit_trigger_row ON "dataSources"."dataSource";
+DROP TRIGGER audit_trigger_stm ON "dataSources"."dataSource";
+DROP TRIGGER audit_trigger_row ON "dataSources"."raster";
+DROP TRIGGER audit_trigger_stm ON "dataSources"."raster";
+DROP TRIGGER audit_trigger_row ON "dataSources"."vector";
+DROP TRIGGER audit_trigger_stm ON "dataSources"."vector";
+DROP TRIGGER audit_trigger_row ON "dataSources"."wms";
+DROP TRIGGER audit_trigger_stm ON "dataSources"."wms";
+DROP TRIGGER audit_trigger_row ON "dataSources"."wmts";
+DROP TRIGGER audit_trigger_stm ON "dataSources"."wmts";
+
+DROP TRIGGER audit_trigger_row ON "metadata"."areaTree";
+DROP TRIGGER audit_trigger_stm ON "metadata"."areaTree";
+DROP TRIGGER audit_trigger_row ON "metadata"."areaTreeLevel";
+DROP TRIGGER audit_trigger_stm ON "metadata"."areaTreeLevel";
+DROP TRIGGER audit_trigger_row ON "metadata"."attribute";
+DROP TRIGGER audit_trigger_stm ON "metadata"."attribute";
+DROP TRIGGER audit_trigger_row ON "metadata"."attributeSet";
+DROP TRIGGER audit_trigger_stm ON "metadata"."attributeSet";
+DROP TRIGGER audit_trigger_row ON "metadata"."case";
+DROP TRIGGER audit_trigger_stm ON "metadata"."case";
+DROP TRIGGER audit_trigger_row ON "metadata"."layerTemplate";
+DROP TRIGGER audit_trigger_stm ON "metadata"."layerTemplate";
+DROP TRIGGER audit_trigger_row ON "metadata"."period";
+DROP TRIGGER audit_trigger_stm ON "metadata"."period";
+DROP TRIGGER audit_trigger_row ON "metadata"."place";
+DROP TRIGGER audit_trigger_stm ON "metadata"."place";
+DROP TRIGGER audit_trigger_row ON "metadata"."scenario";
+DROP TRIGGER audit_trigger_stm ON "metadata"."scenario";
+DROP TRIGGER audit_trigger_row ON "metadata"."scope";
+DROP TRIGGER audit_trigger_stm ON "metadata"."scope";
+DROP TRIGGER audit_trigger_row ON "metadata"."style";
+DROP TRIGGER audit_trigger_stm ON "metadata"."style";
+DROP TRIGGER audit_trigger_row ON "metadata"."tag";
+DROP TRIGGER audit_trigger_stm ON "metadata"."tag";
+
+DROP TRIGGER audit_trigger_row ON "specific"."esponFuoreIndicator";
+DROP TRIGGER audit_trigger_stm ON "specific"."esponFuoreIndicator";
+DROP TRIGGER audit_trigger_row ON "specific"."lpisChangeCase";
+DROP TRIGGER audit_trigger_stm ON "specific"."lpisChangeCase";
+
+DROP TRIGGER audit_trigger_row ON "views"."view";
+DROP TRIGGER audit_trigger_stm ON "views"."view";

--- a/migrations/202007291339.do.sql
+++ b/migrations/202007291339.do.sql
@@ -1,0 +1,24 @@
+ALTER TABLE "user"."permissions"
+  ADD COLUMN "resourceGroup" TEXT;
+
+DROP INDEX "user"."user_permissions_resource_idx";
+CREATE INDEX "user_permissions_resource_idx" ON "user"."permissions" ("resourceGroup", "resourceType", "resourceKey");
+
+DROP VIEW "user"."v_userPermissions";
+CREATE VIEW "user"."v_userPermissions" AS
+ SELECT p."resourceGroup",
+    p."resourceType",
+    p."resourceKey",
+    p.permission,
+    up."userKey"
+   FROM ("user".permissions p
+     JOIN "user"."userPermissions" up ON ((up."permissionKey" = p.key)))
+UNION
+ SELECT p."resourceGroup",
+    p."resourceType",
+    p."resourceKey",
+    p.permission,
+    ug."userKey"
+   FROM (("user".permissions p
+     JOIN "user"."groupPermissions" gp ON ((gp."permissionKey" = p.key)))
+     JOIN "user"."userGroups" ug ON ((ug."groupKey" = gp."groupKey")));

--- a/migrations/202007291339.undo.sql
+++ b/migrations/202007291339.undo.sql
@@ -1,0 +1,22 @@
+DROP VIEW "user"."v_userPermissions";
+CREATE VIEW "user"."v_userPermissions" AS
+ SELECT p."resourceType",
+    p."resourceKey",
+    p.permission,
+    up."userKey"
+   FROM ("user".permissions p
+     JOIN "user"."userPermissions" up ON ((up."permissionKey" = p.key)))
+UNION
+ SELECT p."resourceType",
+    p."resourceKey",
+    p.permission,
+    ug."userKey"
+   FROM (("user".permissions p
+     JOIN "user"."groupPermissions" gp ON ((gp."permissionKey" = p.key)))
+     JOIN "user"."userGroups" ug ON ((ug."groupKey" = gp."groupKey")));
+
+DROP INDEX "user"."user_permissions_resource_idx";
+CREATE INDEX "user_permissions_resource_idx" ON "user"."permissions" ("resourceType", "resourceKey");
+
+ALTER TABLE "user"."permissions"
+  DROP COLUMN "resourceGroup";

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@hapi/joi": "^17.1.1",
-    "@imatic/pgqb": "^0.1.18",
+    "@imatic/pgqb": "^0.1.19",
     "@turf/turf": "^5.1.6",
     "bcrypt": "^4.0.1",
     "body-parser": "^1.19.0",

--- a/src/applications/core/plan.js
+++ b/src/applications/core/plan.js
@@ -1230,33 +1230,132 @@ module.exports = {
             },
         },
         dataSource: {
+            type: {
+                dispatchColumn: 'type',
+                key: 'sourceKey',
+                types: {
+                    vector: {
+                        context: {
+                            list: {
+                                columns: ['layerName', 'tableName'],
+                            },
+                            create: {
+                                columns: ['layerName', 'tableName'],
+                            },
+                            update: {
+                                columns: ['layerName', 'tableName'],
+                            },
+                        },
+                        columns: {
+                            layerName: {
+                                defaultValue: null,
+                                schema: Joi.string(),
+                            },
+                            tableName: {
+                                defaultValue: null,
+                                schema: Joi.string(),
+                            },
+                        },
+                    },
+                    raster: {
+                        context: {
+                            list: {
+                                columns: ['layerName', 'tableName'],
+                            },
+                            create: {
+                                columns: ['layerName', 'tableName'],
+                            },
+                            update: {
+                                columns: ['layerName', 'tableName'],
+                            },
+                        },
+                        columns: {
+                            layerName: {
+                                defaultValue: null,
+                                schema: Joi.string(),
+                            },
+                            tableName: {
+                                defaultValue: null,
+                                schema: Joi.string(),
+                            },
+                        },
+                    },
+                    wms: {
+                        context: {
+                            list: {
+                                columns: [
+                                    'url',
+                                    'layers',
+                                    'styles',
+                                    'configuration',
+                                ],
+                            },
+                            create: {
+                                columns: [
+                                    'url',
+                                    'layers',
+                                    'styles',
+                                    'configuration',
+                                ],
+                            },
+                            update: {
+                                columns: [
+                                    'url',
+                                    'layers',
+                                    'styles',
+                                    'configuration',
+                                ],
+                            },
+                        },
+                        columns: {
+                            url: {
+                                defaultValue: null,
+                                schema: Joi.string(),
+                            },
+                            layers: {
+                                defaultValue: null,
+                                schema: Joi.string(),
+                            },
+                            styles: {
+                                defaultValue: null,
+                                schema: Joi.string(),
+                            },
+                            configuration: {
+                                defaultValue: null,
+                                schema: Joi.object(),
+                            },
+                        },
+                    },
+                    wmts: {
+                        context: {
+                            list: {
+                                columns: ['urls'],
+                            },
+                            create: {
+                                columns: ['urls'],
+                            },
+                            update: {
+                                columns: ['urls'],
+                            },
+                        },
+                        columns: {
+                            urls: {
+                                defaultValue: null,
+                                schema: Joi.array().items(Joi.string()),
+                            },
+                        },
+                    },
+                },
+            },
             context: {
                 list: {
-                    columns: [
-                        'key',
-                        'nameInternal',
-                        'attribution',
-                        'type',
-                        'sourceKey',
-                    ],
+                    columns: ['key', 'nameInternal', 'attribution', 'type'],
                 },
                 create: {
-                    columns: [
-                        'key',
-                        'nameInternal',
-                        'attribution',
-                        'type',
-                        'sourceKey',
-                    ],
+                    columns: ['key', 'nameInternal', 'attribution', 'type'],
                 },
                 update: {
-                    columns: [
-                        'key',
-                        'nameInternal',
-                        'attribution',
-                        'type',
-                        'sourceKey',
-                    ],
+                    columns: ['key', 'nameInternal', 'attribution', 'type'],
                 },
             },
             columns: {
@@ -1274,11 +1373,13 @@ module.exports = {
                 },
                 type: {
                     defaultValue: null,
-                    schema: Joi.string(),
-                },
-                sourceKey: {
-                    defaultValue: null,
-                    schema: Joi.string().uuid(),
+                    schema: Joi.string().valid(
+                        null,
+                        'raster',
+                        'vector',
+                        'wms',
+                        'wmts'
+                    ),
                 },
             },
         },

--- a/src/applications/core/plan.js
+++ b/src/applications/core/plan.js
@@ -1176,7 +1176,8 @@ module.exports = {
         },
     },
     dataSources: {
-        attributeDataSource: {
+        attribute: {
+            table: 'attributeDataSource',
             context: {
                 list: {
                     columns: [
@@ -1229,7 +1230,8 @@ module.exports = {
                 },
             },
         },
-        dataSource: {
+        spatial: {
+            table: 'dataSource',
             type: {
                 dispatchColumn: 'type',
                 key: 'sourceKey',

--- a/src/applications/demo/router.js
+++ b/src/applications/demo/router.js
@@ -1,3 +1,5 @@
+const getPlan = require('../plan').get;
+
 module.exports = [
     {
         path: '/demo/greet',
@@ -10,6 +12,18 @@ module.exports = [
         responses: {200: {description: 'Response description'}},
         handler: function (request, response) {
             response.status(200).send('hello there!!!');
+        },
+    },
+    {
+        path: '/demo/show-groups',
+        method: 'get',
+        swagger: {
+            tags: ['demo'],
+            summary: 'Shows configured groups of the plan',
+        },
+        responses: {200: {}},
+        handler: function (request, response) {
+            response.status(200).json(Object.keys(getPlan()));
         },
     },
 ];

--- a/src/applications/index.js
+++ b/src/applications/index.js
@@ -9,6 +9,7 @@ const {errorMiddleware} = require('../modules/error/index');
 const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 const _ = require('lodash/fp');
+const p = require('./plan');
 
 function appendApplication(result, application) {
     return _.reduce(
@@ -39,6 +40,7 @@ function apiRouter() {
     const router = express.Router();
 
     const plan = planCompiler.compile(config.plan);
+    p.init(plan);
     const api = [
         ...createLoginApi(plan),
         ...restRouter.createAll(plan),

--- a/src/applications/index.js
+++ b/src/applications/index.js
@@ -11,6 +11,9 @@ const bodyParser = require('body-parser');
 const _ = require('lodash/fp');
 const p = require('./plan');
 
+/**
+ * Reducing function for application merging.
+ */
 function appendApplication(result, application) {
     return _.reduce(
         function (result, k) {
@@ -27,15 +30,24 @@ function appendApplication(result, application) {
     );
 }
 
+/**
+ * Merges given applications into one config.
+ */
 function mergeApplications(...applications) {
     return _.reduce(appendApplication, {}, applications);
 }
 
+/**
+ * Merged config of all applications
+ */
 const config = mergeApplications(
     require('./core/index'),
     require('./demo/index')
 );
 
+/**
+ * Creates api router with swagger documentation.
+ */
 function apiRouter() {
     const router = express.Router();
 

--- a/src/applications/index.js
+++ b/src/applications/index.js
@@ -17,7 +17,7 @@ function appendApplication(result, application) {
                 return _.set(k, application[k], result);
             }
 
-            const appendHandler = _.isObject(result[k]) ? _.merge : _.concat;
+            const appendHandler = _.isArray(result[k]) ? _.concat : _.merge;
 
             return _.set(k, appendHandler(result[k], application[k]), result);
         },

--- a/src/applications/plan.js
+++ b/src/applications/plan.js
@@ -3,6 +3,9 @@
  */
 let _plan;
 
+/**
+ * Initializes this module with final compiled plan.
+ */
 function init(plan) {
     if (_plan != null) {
         throw new Error('Plan is already initialized');

--- a/src/applications/plan.js
+++ b/src/applications/plan.js
@@ -1,0 +1,17 @@
+/**
+ * Compiled plan available to the whole application
+ */
+let _plan;
+
+function init(plan) {
+    if (_plan != null) {
+        throw new Error('Plan is already initialized');
+    }
+
+    _plan = plan;
+}
+
+module.exports = {
+    get: () => _plan,
+    init,
+};

--- a/src/db.js
+++ b/src/db.js
@@ -69,6 +69,9 @@ async function transactional(cb) {
     }
 }
 
+/**
+ * @returns {import('pg').Client}
+ */
 function getSuperUserClient() {
     return new Client(config.pgConfig.superuser || config.pgConfig.normal);
 }

--- a/src/joi.js
+++ b/src/joi.js
@@ -1,7 +1,7 @@
 const Joi = require('@hapi/joi');
 
 module.exports = Joi.extend((joi) => ({
-    type: 'stringArray',
+    type: 'stringArray', // array items are encoded in string, separated by comma
     base: Joi.array().meta({baseType: 'array'}),
     coerce: (value) => {
         if (value != null && value.split) {

--- a/src/modules/error/index.js
+++ b/src/modules/error/index.js
@@ -1,10 +1,13 @@
 const db = require('../../db');
 const {SQL} = require('sql-template-strings');
 
+/**
+ * This error can be passed to expressjs error handler to log some error data and show logId to the user.
+ */
 class HttpError extends Error {
     /**
-     * @param {number} status
-     * @param {object} data
+     * @param {number} status Http response status
+     * @param {object} data Error data
      */
     constructor(status, data) {
         super();
@@ -14,6 +17,8 @@ class HttpError extends Error {
 }
 
 /**
+ * Logs data into db and returns log id.
+ *
  * @param {object} data
  *
  * @returns {Promise<number>}
@@ -26,6 +31,9 @@ async function log(data) {
     return res.rows[0]['key'];
 }
 
+/**
+ * Extracts useful information from request that should be logged with error.
+ */
 function requestData(request) {
     return {
         url: request.url,
@@ -34,6 +42,9 @@ function requestData(request) {
     };
 }
 
+/**
+ * Formats given error.
+ */
 function formatError(err) {
     if (err instanceof HttpError) {
         return {status: err.status, data: err.data};
@@ -53,6 +64,9 @@ function formatError(err) {
     return {status: 500, data: err};
 }
 
+/**
+ * Middleware that logs given error into db and shows users it's id.
+ */
 async function errorMiddleware(err, request, response, next) {
     const formatted = formatError(err);
     const reqData = requestData(request);

--- a/src/modules/login/query.js
+++ b/src/modules/login/query.js
@@ -46,7 +46,7 @@ function getUserInfoByKey(key) {
 /**
  * @param {string} key
  *
- * @returns {Promise<{resourceType: string, permission: string}[]>}
+ * @returns {Promise<{resourceGroup: string, resourceType: string, permission: string}[]>}
  */
 function userPermissionsByKey(key) {
     if (key == null) {
@@ -57,7 +57,7 @@ function userPermissionsByKey(key) {
         .query(
             `
 SELECT
-  "p"."resourceType", "p"."permission"
+  "p"."resourceGroup", "p"."resourceType", "p"."permission"
 FROM
   "${schema}"."v_userPermissions" "p"
 WHERE

--- a/src/modules/login/query.js
+++ b/src/modules/login/query.js
@@ -4,6 +4,12 @@ const {SQL} = require('sql-template-strings');
 
 const schema = config.pgSchema.user;
 
+/**
+ * @param {string} email
+ * @param {string} password
+ *
+ * @returns {Promise<{key: string, password: string}>}
+ */
 function getUser(email, password) {
     return db
         .query(
@@ -18,6 +24,11 @@ function getUser(email, password) {
         });
 }
 
+/**
+ * @param {string} key
+ *
+ * @returns {Promise<{email: string, name: string, phone: string}>}
+ */
 function getUserInfoByKey(key) {
     if (key == null) {
         return;
@@ -32,6 +43,11 @@ function getUserInfoByKey(key) {
         .then((res) => res.rows[0]);
 }
 
+/**
+ * @param {string} key
+ *
+ * @returns {Promise<{resourceType: string, permission: string}[]>}
+ */
 function userPermissionsByKey(key) {
     if (key == null) {
         return [];

--- a/src/modules/login/router.js
+++ b/src/modules/login/router.js
@@ -14,20 +14,24 @@ const UserType = {
 };
 
 /**
- * @param {{resourceType: string, permission: string}[]} permissions
+ * @param {{resourceGroup: string, resourceType: string, permission: string}[]} permissions
  * @param {object} plan
  *
  * @returns {Object<string, Object<string, Object<string, true>>>}
  */
 function formatPermissions(permissions, plan) {
-    const permissionsByResourceType = _.groupBy(
+    const permissionsByResourceGroup = _.groupBy(
         permissions,
-        (p) => p.resourceType
+        (p) => p.resourceGroup
     );
 
     const formattedPermissions = {};
     _.each(plan, (dataType, group) => {
         formattedPermissions[group] = {};
+        const permissionsByResourceType = _.groupBy(
+            permissionsByResourceGroup[group],
+            (p) => p.resourceType
+        );
         _.each(_.keys(dataType), (resourceType) => {
             if (permissionsByResourceType[resourceType] == null) {
                 return;

--- a/src/modules/login/router.js
+++ b/src/modules/login/router.js
@@ -13,6 +13,12 @@ const UserType = {
     GUEST: 'guest',
 };
 
+/**
+ * @param {{resourceType: string, permission: string}[]} permissions
+ * @param {object} plan
+ *
+ * @returns {Object<string, Object<string, Object<string, true>>>}
+ */
 function formatPermissions(permissions, plan) {
     const permissionsByResourceType = _.groupBy(
         permissions,

--- a/src/modules/rest/compiler.js
+++ b/src/modules/rest/compiler.js
@@ -26,8 +26,17 @@ function compileColumns(columns) {
     return mapValuesWithKeys(compileColumn, columns);
 }
 
+function compileTypes(types) {
+    return _.mapValues(compileType, types);
+}
+
 function compileType(type) {
-    return _.update('columns', compileColumns, type);
+    const withColumns = _.update('columns', compileColumns, type);
+    if (type.type == null) {
+        return withColumns;
+    }
+
+    return _.update(['type', 'types'], compileTypes, withColumns);
 }
 
 function compileGroup(group) {

--- a/src/modules/rest/compiler.js
+++ b/src/modules/rest/compiler.js
@@ -64,7 +64,23 @@ function compileGroup(group) {
  * ### modifyExpr (optional)
  *   Returns query expression used as a value in create and update queries.
  *
- * ## relations
+ * ## type (optional)
+ *
+ * Adds support for many types inside of this type. Each type can have it's own additional set of columns.
+ *
+ * ### dispatchColumn (required)
+ *
+ * Column name that decided of which type given record is.
+ *
+ * ### key (required)
+ *
+ * Db column that stores type of type specific table table.
+ *
+ * ### types (required)
+ *
+ * Map with type as key. Value is map with supported keys: columns, context, that are merged into based type.
+ *
+ * ## relations (optional)
  *
  * ## context (required)
  *

--- a/src/modules/rest/middlewares/dependentType.js
+++ b/src/modules/rest/middlewares/dependentType.js
@@ -1,0 +1,95 @@
+const apiUtil = require('../../../util/api');
+const {HttpError} = require('../../error');
+const _ = require('lodash/fp');
+const q = require('../query');
+
+const mapWithKeys = _.map.convert({cap: false});
+
+/**
+ * Useful in PUT operation.
+ *
+ * - Validates type properly by adding `type` attribute if not specified.
+ * - Adds type info into `type` key of records.
+ */
+function createDependentTypeMiddleware({plan, group}) {
+    return async function (request, response, next) {
+        let validationError = null;
+        const parameters = request.match.data.parameters;
+        const data = request.parameters.body.data;
+        const BodySchema = parameters.body;
+
+        const newData = await Promise.all(
+            mapWithKeys(async function (records, type) {
+                const typeSchema = plan[group][type];
+                if (typeSchema.type == null) {
+                    return records;
+                }
+
+                const dispatchColumn = typeSchema.type.dispatchColumn;
+                const relationKey = typeSchema.type.key;
+
+                const typeColumns = await q.typeColumns(
+                    {plan, group, type},
+                    records
+                );
+
+                const typeColumnsByKey = _.indexBy((r) => r.key, typeColumns);
+
+                const recordsWithType = _.map((r) => {
+                    const val = _.get(
+                        [r.key, dispatchColumn],
+                        typeColumnsByKey
+                    );
+
+                    if (
+                        val === undefined ||
+                        r.data.hasOwnProperty(dispatchColumn)
+                    ) {
+                        return r;
+                    }
+
+                    return _.set(['data', dispatchColumn], val, r);
+                }, records);
+
+                if (BodySchema != null) {
+                    const validationResult = BodySchema.validate(
+                        {data: {[type]: recordsWithType}},
+                        {
+                            abortEarly: false,
+                        }
+                    );
+                    if (validationResult.error) {
+                        validationError = validationResult.error;
+                    }
+                }
+
+                const recordsWithKeyAndRelation = _.map((r) => {
+                    const val = _.get(r.key, typeColumnsByKey);
+
+                    if (val == null) {
+                        return r;
+                    }
+
+                    return _.set(
+                        'type',
+                        _.pick([relationKey, dispatchColumn], val),
+                        r
+                    );
+                }, recordsWithType);
+
+                return recordsWithKeyAndRelation;
+            }, data)
+        );
+
+        if (validationError == null) {
+            request.parameters.body.data = _.zipObject(_.keys(data), newData);
+            return next();
+        }
+
+        return next(
+            new HttpError(400, apiUtil.createDataErrorObject(validationError))
+        );
+    };
+}
+
+module.exports = createDependentTypeMiddleware;

--- a/src/modules/rest/query.js
+++ b/src/modules/rest/query.js
@@ -293,10 +293,10 @@ function listDependentTypeQuery({plan, group, type}, alias) {
     const joins = qb.append(
         ..._fp.map((table) => {
             const al = `_t_${table}`;
-            const columns = _fp.get(
+            const columns = _fp.getOr(
+                {},
                 ['type', 'types', table, 'columns'],
-                typeSchema,
-                {}
+                typeSchema
             );
 
             _.forEach(columns, (c, name) => {
@@ -765,12 +765,12 @@ function updateType({plan, group, type, client}, record) {
 
     if (dispatchValue === prevDispatchValue) {
         return updateDependentType({plan, group, type, client}, record);
-    } else {
-        return Promise.all([
-            deleteDependentType({plan, group, type, client}, record),
-            createDependentType({plan, group, type, client}, record),
-        ]).then(([r1, r2]) => r2);
     }
+
+    return Promise.all([
+        deleteDependentType({plan, group, type, client}, record),
+        createDependentType({plan, group, type, client}, record),
+    ]).then(([r1, r2]) => r2);
 }
 
 async function update({plan, group, type, client}, records) {

--- a/src/modules/rest/router.js
+++ b/src/modules/rest/router.js
@@ -206,6 +206,7 @@ function createGroup(plan, group) {
                 const data = request.parameters.body.data;
 
                 const requiredPermissions = Object.keys(data).map((k) => ({
+                    resourceGroup: group,
                     resourceType: k,
                     permission: 'create',
                 }));
@@ -264,6 +265,7 @@ function createGroup(plan, group) {
                 const data = request.parameters.body.data;
 
                 const requiredPermissions = Object.keys(data).map((k) => ({
+                    resourceGroup: group,
                     resourceType: k,
                     permission: 'update',
                     resourceKey: data[k].map((m) => m.key),
@@ -323,6 +325,7 @@ function createGroup(plan, group) {
                 const data = request.parameters.body.data;
 
                 const requiredPermissions = Object.keys(data).map((k) => ({
+                    resourceGroup: group,
                     resourceType: k,
                     permission: 'delete',
                     resourceKey: data[k].map((m) => m.key),

--- a/src/modules/rest/router.js
+++ b/src/modules/rest/router.js
@@ -58,7 +58,14 @@ function formatList(recordsByType, page) {
 }
 
 function filterListParamsByType(plan, group, type, params) {
-    const columnNames = Object.keys(plan[group][type].columns);
+    const typeSchema = plan[group][type];
+    const columnNames = _.concat(
+        _.keys(_.get(typeSchema, 'columns', {})),
+        _.flatMap(_.get(typeSchema, ['type', 'types'], {}), (type) =>
+            _.keys(_.get(type, 'columns', {}))
+        )
+    );
+
     const columnNamesSet = new Set(columnNames);
 
     return _.mapValues(params, function (v, name) {

--- a/src/modules/rest/router.js
+++ b/src/modules/rest/router.js
@@ -2,16 +2,12 @@ const parameters = require('../../middlewares/parameters');
 const userMiddleware = require('../../middlewares/user');
 const authMiddleware = require('../../middlewares/auth');
 const autoLoginMiddleware = require('../../middlewares/auto-login');
+const createDependentTypeMiddleware = require('./middlewares/dependentType');
 const permission = require('../../permission');
 const _ = require('lodash');
-const _fp = require('lodash/fp');
 const schema = require('./schema');
 const q = require('./query');
 const db = require('../../db');
-const {query} = require('express');
-const Joi = require('@hapi/joi');
-const apiUtil = require('../../util/api');
-const {HttpError} = require('../error');
 
 const defaultPermissions = {
     view: false,
@@ -75,90 +71,6 @@ function filterListParamsByType(plan, group, type, params) {
 
         return v;
     });
-}
-
-function createDependentTypeMiddleware({plan, group}) {
-    return async function (request, response, next) {
-        let validationError = null;
-        const parameters = request.match.data.parameters;
-        const data = request.parameters.body.data;
-        const BodySchema = parameters.body;
-
-        const newData = await Promise.all(
-            _.map(data, async function (records, type) {
-                const typeSchema = plan[group][type];
-                if (typeSchema.type == null) {
-                    return records;
-                }
-
-                const dispatchColumn = typeSchema.type.dispatchColumn;
-                const relationKey = typeSchema.type.key;
-
-                const typeColumns = await q.typeColumns(
-                    {plan, group, type},
-                    records
-                );
-
-                const typeColumnsByKey = _fp.indexBy((r) => r.key, typeColumns);
-
-                const recordsWithType = _fp.map((r) => {
-                    const val = _fp.get(
-                        [r.key, dispatchColumn],
-                        typeColumnsByKey
-                    );
-
-                    if (
-                        val === undefined ||
-                        r.data.hasOwnProperty(dispatchColumn)
-                    ) {
-                        return r;
-                    }
-
-                    return _fp.set(['data', dispatchColumn], val, r);
-                }, records);
-
-                if (BodySchema != null) {
-                    const validationResult = BodySchema.validate(
-                        {data: {[type]: recordsWithType}},
-                        {
-                            abortEarly: false,
-                        }
-                    );
-                    if (validationResult.error) {
-                        validationError = validationResult.error;
-                    }
-                }
-
-                const recordsWithKeyAndRelation = _fp.map((r) => {
-                    const val = _fp.get(r.key, typeColumnsByKey);
-
-                    if (val == null) {
-                        return r;
-                    }
-
-                    return _fp.set(
-                        'type',
-                        _fp.pick([relationKey, dispatchColumn], val),
-                        r
-                    );
-                }, recordsWithType);
-
-                return recordsWithKeyAndRelation;
-            })
-        );
-
-        if (validationError == null) {
-            request.parameters.body.data = _.zipObject(_.keys(data), newData);
-            next();
-        } else {
-            return next(
-                new HttpError(
-                    400,
-                    apiUtil.createDataErrorObject(validationError)
-                )
-            );
-        }
-    };
 }
 
 function createGroup(plan, group) {

--- a/src/modules/rest/router.js
+++ b/src/modules/rest/router.js
@@ -9,6 +9,19 @@ const schema = require('./schema');
 const q = require('./query');
 const db = require('../../db');
 
+/**
+ * @typedef {Object} Permissions
+ * @property {boolean} view
+ * @property {boolean} create
+ * @property {boolean} update
+ * @property {boolean} delete
+ *
+ * @typedef {Object} Row
+ * @property {string} key
+ * @property {object} data
+ * @property {{guest: Permissions, activeUser: Permissions}} permissions
+ */
+
 const defaultPermissions = {
     view: false,
     create: false,
@@ -16,6 +29,12 @@ const defaultPermissions = {
     delete: false,
 };
 
+/**
+ * @param {object} row
+ * @param {string} key
+ *
+ * @returns {Permissions}
+ */
 function formatPermissions(row, key) {
     return Object.assign(
         {},
@@ -27,6 +46,11 @@ function formatPermissions(row, key) {
     );
 }
 
+/**
+ * @param {object} row
+ *
+ * @returns {Row}
+ */
 function formatRow(row) {
     return {
         key: row.key,
@@ -38,6 +62,12 @@ function formatRow(row) {
     };
 }
 
+/**
+ * @param {Object<string, object>} recordsByType
+ * @param {{limit: number, offset: number}} page
+ *
+ * @returns {{data: Object<string, Row[]>, success: true, total: Object<string, number>, limit?: number, offset?: number}}
+ */
 function formatList(recordsByType, page) {
     const data = {
         data: _.mapValues(recordsByType, (r) => r.rows.map(formatRow)),
@@ -57,6 +87,14 @@ function formatList(recordsByType, page) {
     return data;
 }
 
+/**
+ * @param {import('./compiler').Plan} plan
+ * @param {string} group
+ * @param {string} type
+ * @param {object} params
+ *
+ * @returns {object}
+ */
 function filterListParamsByType(plan, group, type, params) {
     const typeSchema = plan[group][type];
     const columnNames = _.concat(
@@ -80,6 +118,12 @@ function filterListParamsByType(plan, group, type, params) {
     });
 }
 
+/**
+ * @param {import('./compiler').Plan} plan
+ * @param {string} group
+ *
+ * @returns {import('../routing').RouteData[]}
+ */
 function createGroup(plan, group) {
     return [
         {
@@ -310,6 +354,11 @@ function createGroup(plan, group) {
     ];
 }
 
+/**
+ * @param {import('./compiler').Plan} plan
+ *
+ * @returns {import('../routing').RouteData[]}
+ */
 function createAll(plan) {
     const handlers = [];
 

--- a/src/modules/rest/schema.js
+++ b/src/modules/rest/schema.js
@@ -1,5 +1,6 @@
 const Joi = require('../../joi');
 const _ = require('lodash');
+const _fp = require('lodash/fp');
 
 function colFilterSchema(col) {
     const type = col.schema.type;
@@ -43,6 +44,8 @@ function colFilterSchema(col) {
             );
         case 'object':
             return null;
+        case 'array':
+            return null;
     }
 
     throw new Error(`Type "${type}" is not supported in filter.`);
@@ -84,7 +87,18 @@ function mergeColumns(columns) {
 }
 
 function listBody(plan, group) {
-    const columns = mergeColumns(_.flatMap(plan[group], (s) => s.columns));
+    const columns = mergeColumns(
+        _.flatMap(plan[group], (s) => {
+            const types = _.get(s, ['type', 'types'], {});
+
+            return mergeColumns(
+                _.concat(
+                    s.columns,
+                    _.map(types, (t) => t.columns)
+                )
+            );
+        })
+    );
 
     return Joi.object()
         .meta({className: `${group}List`})
@@ -142,6 +156,86 @@ function relationSchemas(plan, group, type) {
 
 function createBody(plan, group) {
     const dataKeys = _.mapValues(plan[group], function (typeSchema, type) {
+        if (typeSchema.type != null) {
+            const validTypes = Array.from(
+                typeSchema.columns[typeSchema.type.dispatchColumn].schema
+                    ._valids._values
+            );
+
+            return Joi.array()
+                .items(
+                    Joi.alternatives().try(
+                        ..._.map(validTypes, (currentType) => {
+                            const columns = _.merge(
+                                {},
+                                _.pick(
+                                    _fp.update(
+                                        [
+                                            typeSchema.type.dispatchColumn,
+                                            'schema',
+                                        ],
+                                        function (schema) {
+                                            return schema.valid(
+                                                Joi.override,
+                                                currentType
+                                            );
+                                        },
+                                        typeSchema.columns
+                                    ),
+                                    typeSchema.context.create.columns
+                                ),
+                                _.pick(
+                                    _.get(
+                                        typeSchema,
+                                        [
+                                            'type',
+                                            'types',
+                                            currentType,
+                                            'columns',
+                                        ],
+                                        {}
+                                    ),
+                                    _.get(
+                                        typeSchema,
+                                        [
+                                            'type',
+                                            'types',
+                                            currentType,
+                                            'context',
+                                            'create',
+                                            'columns',
+                                        ],
+                                        []
+                                    )
+                                )
+                            );
+
+                            const keyCol = columns.key;
+                            const dataCols = _.omit(columns, ['key']);
+
+                            const rs = relationSchemas(plan, group, type);
+
+                            return Joi.object().keys({
+                                key: keyCol.schema.default(keyCol.defaultValue),
+                                data: Joi.object()
+                                    .keys(
+                                        Object.assign(
+                                            {},
+                                            _.mapValues(
+                                                dataCols,
+                                                dataColCreateSchema
+                                            ),
+                                            rs
+                                        )
+                                    )
+                                    .required(),
+                            });
+                        })
+                    )
+                )
+                .min(1);
+        }
+
         const columns = _.pick(
             typeSchema.columns,
             typeSchema.context.create.columns
@@ -184,6 +278,86 @@ function dataColUpdateSchema(col) {
 
 function updateBody(plan, group) {
     const dataKeys = _.mapValues(plan[group], function (typeSchema, type) {
+        if (typeSchema.type != null) {
+            const validTypes = Array.from(
+                typeSchema.columns[typeSchema.type.dispatchColumn].schema
+                    ._valids._values
+            );
+
+            return Joi.array()
+                .items(
+                    Joi.alternatives().try(
+                        ..._.map(validTypes, (currentType) => {
+                            const columns = _.merge(
+                                {},
+                                _.pick(
+                                    _fp.update(
+                                        [
+                                            typeSchema.type.dispatchColumn,
+                                            'schema',
+                                        ],
+                                        function (schema) {
+                                            return schema.valid(
+                                                Joi.override,
+                                                currentType
+                                            );
+                                        },
+                                        typeSchema.columns
+                                    ),
+                                    typeSchema.context.create.columns
+                                ),
+                                _.pick(
+                                    _.get(
+                                        typeSchema,
+                                        [
+                                            'type',
+                                            'types',
+                                            currentType,
+                                            'columns',
+                                        ],
+                                        {}
+                                    ),
+                                    _.get(
+                                        typeSchema,
+                                        [
+                                            'type',
+                                            'types',
+                                            currentType,
+                                            'context',
+                                            'create',
+                                            'columns',
+                                        ],
+                                        []
+                                    )
+                                )
+                            );
+
+                            const keyCol = columns.key;
+                            const dataCols = _.omit(columns, ['key']);
+
+                            const rs = relationSchemas(plan, group, type);
+
+                            return Joi.object().keys({
+                                key: keyCol.schema.required(),
+                                data: Joi.object()
+                                    .keys(
+                                        Object.assign(
+                                            {},
+                                            _.mapValues(
+                                                dataCols,
+                                                dataColUpdateSchema
+                                            ),
+                                            rs
+                                        )
+                                    )
+                                    .required(),
+                            });
+                        })
+                    )
+                )
+                .min(1);
+        }
+
         const columns = _.pick(
             typeSchema.columns,
             typeSchema.context.update.columns

--- a/src/modules/rest/schema.js
+++ b/src/modules/rest/schema.js
@@ -2,6 +2,11 @@ const Joi = require('../../joi');
 const _ = require('lodash');
 const _fp = require('lodash/fp');
 
+/**
+ * @param {import('./compiler').Column} col
+ *
+ * @returns {object|null}
+ */
 function colFilterSchema(col) {
     const type = col.schema.type;
     const schema = col.schema;
@@ -51,6 +56,12 @@ function colFilterSchema(col) {
     throw new Error(`Type "${type}" is not supported in filter.`);
 }
 
+/**
+ * @param {import('./compiler').Plan} plan
+ * @param {string} group
+ *
+ * @returns {object}
+ */
 function listPath(plan, group) {
     const types = Object.keys(plan[group]);
 
@@ -86,6 +97,12 @@ function mergeColumns(columns) {
     return merged;
 }
 
+/**
+ * @param {import('./compiler').Plan} plan
+ * @param {string} group
+ *
+ * @returns {object}
+ */
 function listBody(plan, group) {
     const columns = mergeColumns(
         _.flatMap(plan[group], (s) => {
@@ -123,6 +140,11 @@ function listBody(plan, group) {
         });
 }
 
+/**
+ * @param {import('./compiler').Column} col
+ *
+ * @returns {object}
+ */
 function dataColCreateSchema(col) {
     if (col.hasOwnProperty('defaultValue')) {
         return col.schema.default(col.defaultValue);
@@ -131,6 +153,13 @@ function dataColCreateSchema(col) {
     return col.schema.required();
 }
 
+/**
+ * @param {Plan} plan
+ * @param {string} group
+ * @param {string} type
+ *
+ * @returns {object}
+ */
 function relationSchemas(plan, group, type) {
     const relations = plan[group][type].relations;
     const relationSchemas = {};
@@ -154,6 +183,12 @@ function relationSchemas(plan, group, type) {
     return relationSchemas;
 }
 
+/**
+ * @param {import('./compiler').Plan} plan
+ * @param {string} group
+ *
+ * @returns {object}
+ */
 function createBody(plan, group) {
     const dataKeys = _.mapValues(plan[group], function (typeSchema, type) {
         if (typeSchema.type != null) {
@@ -272,10 +307,21 @@ function createBody(plan, group) {
         });
 }
 
+/**
+ * @param {import('./compiler').Column} col
+ *
+ * @returns {object}
+ */
 function dataColUpdateSchema(col) {
     return col.schema;
 }
 
+/**
+ * @param {import('./compiler').Plan} plan
+ * @param {string} group
+ *
+ * @returns {object}
+ */
 function updateBody(plan, group) {
     const dataKeys = _.mapValues(plan[group], function (typeSchema, type) {
         if (typeSchema.type != null) {
@@ -394,6 +440,12 @@ function updateBody(plan, group) {
         });
 }
 
+/**
+ * @param {import('./compiler').Plan} plan
+ * @param {string} group
+ *
+ * @returns {object}
+ */
 function deleteBody(plan, group) {
     const dataKeys = _.mapValues(plan[group], function (typeSchema) {
         const columns = typeSchema.columns;

--- a/src/permission.js
+++ b/src/permission.js
@@ -3,6 +3,7 @@ const db = require('./db');
 
 /**
  * @typedef {object} Permission
+ * @property {string} resourceGroup
  * @property {string} resourceType
  * @property {string} permission
  * @property {Array<string|undefined>=} resourceKey - All resource keys we need access to
@@ -20,6 +21,10 @@ function permissionExpr(permission) {
     );
 
     return qb.expr.and(
+        qb.expr.eq(
+            'p.resourceGroup',
+            qb.val.inlineParam(permission.resourceGroup)
+        ),
         qb.expr.eq(
             'p.resourceType',
             qb.val.inlineParam(permission.resourceType)

--- a/src/security.js
+++ b/src/security.js
@@ -4,6 +4,11 @@ const {SQL} = require('sql-template-strings');
 
 db.init();
 
+/**
+ * @param {string} password
+ *
+ * @returns {Promise<string>}
+ */
 function hashPassword(password) {
     return db
         .query(

--- a/src/uuid.js
+++ b/src/uuid.js
@@ -1,5 +1,8 @@
 const uuid = require('uuid').v1;
 
+/**
+ * @returns {string}
+ */
 function generate() {
     return uuid();
 }

--- a/tests/functional/datasource-test.js
+++ b/tests/functional/datasource-test.js
@@ -1,0 +1,131 @@
+const {assert} = require('chai');
+const fetch = require('node-fetch');
+const jwt = require('jsonwebtoken');
+const config = require('../../config');
+
+function url(path) {
+    return 'http://localhost:' + config.clusterPorts[0] + path;
+}
+
+function createAdminToken() {
+    return (
+        'Bearer ' +
+        jwt.sign(
+            {
+                key: '2d069e3a-f77f-4a1f-aeda-50fd06c8c35d',
+                realKey: '2d069e3a-f77f-4a1f-aeda-50fd06c8c35d',
+                type: 'user',
+            },
+            config.jwt.secret
+        )
+    );
+}
+
+describe('/rest/dataSources', function () {
+    describe('POST /rest/dataSources', function () {
+        const tests = [
+            {
+                name: 'all types',
+                headers: new fetch.Headers({
+                    Authorization: createAdminToken(),
+                    'Content-Type': 'application/json',
+                }),
+                body: JSON.stringify({
+                    data: {
+                        dataSource: [
+                            {
+                                key: '1e1d2a18-9c2f-4e4a-8009-dd5cd05a52c8',
+                                data: {
+                                    nameInternal: 'null type',
+                                    attribution: 'attr',
+                                    type: null,
+                                },
+                            },
+                            {
+                                key: '44e47b74-fb6c-434a-a678-340fb2c6236a',
+                                data: {
+                                    nameInternal: 'raster type',
+                                    attribution: 'attr',
+                                    type: 'raster',
+                                    layerName: 'lr',
+                                    tableName: 'tr',
+                                },
+                            },
+                        ],
+                    },
+                }),
+                expectedResult: {
+                    body: {
+                        data: {
+                            dataSource: [
+                                {
+                                    key: '1e1d2a18-9c2f-4e4a-8009-dd5cd05a52c8',
+                                    data: {
+                                        nameInternal: 'null type',
+                                        attribution: 'attr',
+                                        type: null,
+                                    },
+                                    permissions: {
+                                        activeUser: {
+                                            create: true,
+                                            delete: true,
+                                            update: true,
+                                            view: true,
+                                        },
+                                        guest: {
+                                            create: false,
+                                            delete: false,
+                                            update: false,
+                                            view: false,
+                                        },
+                                    },
+                                },
+                                {
+                                    key: '44e47b74-fb6c-434a-a678-340fb2c6236a',
+                                    data: {
+                                        nameInternal: 'raster type',
+                                        attribution: 'attr',
+                                        type: 'raster',
+                                        layerName: 'lr',
+                                        tableName: 'tr',
+                                    },
+                                    permissions: {
+                                        activeUser: {
+                                            create: true,
+                                            delete: true,
+                                            update: true,
+                                            view: true,
+                                        },
+                                        guest: {
+                                            create: false,
+                                            delete: false,
+                                            update: false,
+                                            view: false,
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                        success: true,
+                        total: 2,
+                    },
+                },
+            },
+        ];
+
+        tests.forEach((test) => {
+            it(test.name, async function () {
+                const response = await fetch(url('/rest/dataSources'), {
+                    method: 'POST',
+                    headers: test.headers,
+                    body: test.body,
+                });
+
+                assert.strictEqual(response.status, 201);
+
+                const data = await response.json();
+                assert.deepStrictEqual(data, test.expectedResult.body);
+            });
+        });
+    });
+});

--- a/tests/functional/datasource-test.js
+++ b/tests/functional/datasource-test.js
@@ -2,6 +2,7 @@ const {assert} = require('chai');
 const fetch = require('node-fetch');
 const jwt = require('jsonwebtoken');
 const config = require('../../config');
+const _ = require('lodash/fp');
 
 function url(path) {
     return 'http://localhost:' + config.clusterPorts[0] + path;
@@ -49,6 +50,37 @@ describe('/rest/dataSources', function () {
                                     type: 'raster',
                                     layerName: 'lr',
                                     tableName: 'tr',
+                                },
+                            },
+                            {
+                                key: 'cb007139-9b66-4e71-a092-8c779a9a1d90',
+                                data: {
+                                    nameInternal: 'vector type',
+                                    attribution: 'vattr',
+                                    type: 'vector',
+                                    layerName: 'lv',
+                                    tableName: 'tv',
+                                },
+                            },
+                            {
+                                key: 'db60a6f7-6a35-4bcb-af9a-24b8149f7bc5',
+                                data: {
+                                    nameInternal: 'wms type',
+                                    attribution: 'wattr',
+                                    type: 'wms',
+                                    url: 'localhost',
+                                    layers: 'wms_layers',
+                                    styles: 'wms_styles',
+                                    configuration: {k: 'v'},
+                                },
+                            },
+                            {
+                                key: 'afed9af4-f48c-4e0c-a22b-9f958161e55d',
+                                data: {
+                                    nameInternal: 'wmts type',
+                                    attribution: 'wmattr',
+                                    type: 'wmts',
+                                    urls: ['loc1', 'loc2'],
                                 },
                             },
                         ],
@@ -104,10 +136,83 @@ describe('/rest/dataSources', function () {
                                         },
                                     },
                                 },
+                                {
+                                    key: 'afed9af4-f48c-4e0c-a22b-9f958161e55d',
+                                    data: {
+                                        nameInternal: 'wmts type',
+                                        attribution: 'wmattr',
+                                        type: 'wmts',
+                                        urls: ['loc1', 'loc2'],
+                                    },
+                                    permissions: {
+                                        activeUser: {
+                                            create: true,
+                                            delete: true,
+                                            update: true,
+                                            view: true,
+                                        },
+                                        guest: {
+                                            create: false,
+                                            delete: false,
+                                            update: false,
+                                            view: false,
+                                        },
+                                    },
+                                },
+                                {
+                                    key: 'cb007139-9b66-4e71-a092-8c779a9a1d90',
+                                    data: {
+                                        nameInternal: 'vector type',
+                                        attribution: 'vattr',
+                                        type: 'vector',
+                                        layerName: 'lv',
+                                        tableName: 'tv',
+                                    },
+                                    permissions: {
+                                        activeUser: {
+                                            create: true,
+                                            delete: true,
+                                            update: true,
+                                            view: true,
+                                        },
+                                        guest: {
+                                            create: false,
+                                            delete: false,
+                                            update: false,
+                                            view: false,
+                                        },
+                                    },
+                                },
+                                {
+                                    key: 'db60a6f7-6a35-4bcb-af9a-24b8149f7bc5',
+                                    data: {
+                                        nameInternal: 'wms type',
+                                        attribution: 'wattr',
+                                        type: 'wms',
+                                        url: 'localhost',
+                                        layers: 'wms_layers',
+                                        styles: 'wms_styles',
+                                        configuration: {k: 'v'},
+                                    },
+                                    permissions: {
+                                        activeUser: {
+                                            create: true,
+                                            delete: true,
+                                            update: true,
+                                            view: true,
+                                        },
+                                        guest: {
+                                            create: false,
+                                            delete: false,
+                                            update: false,
+                                            view: false,
+                                        },
+                                    },
+                                },
                             ],
                         },
                         success: true,
-                        total: 2,
+                        total: 5,
                     },
                 },
             },
@@ -124,7 +229,12 @@ describe('/rest/dataSources', function () {
                 assert.strictEqual(response.status, 201);
 
                 const data = await response.json();
-                assert.deepStrictEqual(data, test.expectedResult.body);
+                const sortedData = _.update(
+                    ['data', 'dataSource'],
+                    (ds) => _.sortBy((r) => r.key, ds),
+                    data
+                );
+                assert.deepStrictEqual(sortedData, test.expectedResult.body);
             });
         });
     });

--- a/tests/functional/datasource-test.js
+++ b/tests/functional/datasource-test.js
@@ -386,6 +386,102 @@ describe('/rest/dataSources', function () {
                     },
                 },
             },
+            {
+                name: 'filtered by ordinary column',
+                headers: new fetch.Headers({
+                    Authorization: createAdminToken(),
+                    'Content-Type': 'application/json',
+                }),
+                body: JSON.stringify({
+                    filter: {nameInternal: {eq: 'raster type'}},
+                    order: [['key', 'ascending']],
+                }),
+                expectedResult: {
+                    body: {
+                        data: {
+                            dataSource: [
+                                {
+                                    key: '44e47b74-fb6c-434a-a678-340fb2c6236a',
+                                    data: {
+                                        nameInternal: 'raster type',
+                                        attribution: 'attr',
+                                        type: 'raster',
+                                        layerName: 'lr',
+                                        tableName: 'tr',
+                                    },
+                                    permissions: {
+                                        activeUser: {
+                                            create: true,
+                                            delete: true,
+                                            update: true,
+                                            view: true,
+                                        },
+                                        guest: {
+                                            create: false,
+                                            delete: false,
+                                            update: false,
+                                            view: false,
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                        success: true,
+                        total: 1,
+                        limit: 100,
+                        offset: 0,
+                        changes: {},
+                    },
+                },
+            },
+            {
+                name: 'filtered by dependent column',
+                headers: new fetch.Headers({
+                    Authorization: createAdminToken(),
+                    'Content-Type': 'application/json',
+                }),
+                body: JSON.stringify({
+                    filter: {layerName: {eq: 'lr'}},
+                    order: [['key', 'ascending']],
+                }),
+                expectedResult: {
+                    body: {
+                        data: {
+                            dataSource: [
+                                {
+                                    key: '44e47b74-fb6c-434a-a678-340fb2c6236a',
+                                    data: {
+                                        nameInternal: 'raster type',
+                                        attribution: 'attr',
+                                        type: 'raster',
+                                        layerName: 'lr',
+                                        tableName: 'tr',
+                                    },
+                                    permissions: {
+                                        activeUser: {
+                                            create: true,
+                                            delete: true,
+                                            update: true,
+                                            view: true,
+                                        },
+                                        guest: {
+                                            create: false,
+                                            delete: false,
+                                            update: false,
+                                            view: false,
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                        success: true,
+                        total: 1,
+                        limit: 100,
+                        offset: 0,
+                        changes: {},
+                    },
+                },
+            },
         ];
 
         tests.forEach((test) => {

--- a/tests/functional/datasource-test.js
+++ b/tests/functional/datasource-test.js
@@ -238,4 +238,402 @@ describe('/rest/dataSources', function () {
             });
         });
     });
+
+    describe('POST ​/rest​/dataSources​/filtered​/dataSource', function () {
+        const tests = [
+            {
+                name: 'all',
+                headers: new fetch.Headers({
+                    Authorization: createAdminToken(),
+                    'Content-Type': 'application/json',
+                }),
+                body: JSON.stringify({
+                    order: [['key', 'ascending']],
+                }),
+                expectedResult: {
+                    body: {
+                        data: {
+                            dataSource: [
+                                {
+                                    key: '1e1d2a18-9c2f-4e4a-8009-dd5cd05a52c8',
+                                    data: {
+                                        nameInternal: 'null type',
+                                        attribution: 'attr',
+                                        type: null,
+                                    },
+                                    permissions: {
+                                        activeUser: {
+                                            create: true,
+                                            delete: true,
+                                            update: true,
+                                            view: true,
+                                        },
+                                        guest: {
+                                            create: false,
+                                            delete: false,
+                                            update: false,
+                                            view: false,
+                                        },
+                                    },
+                                },
+                                {
+                                    key: '44e47b74-fb6c-434a-a678-340fb2c6236a',
+                                    data: {
+                                        nameInternal: 'raster type',
+                                        attribution: 'attr',
+                                        type: 'raster',
+                                        layerName: 'lr',
+                                        tableName: 'tr',
+                                    },
+                                    permissions: {
+                                        activeUser: {
+                                            create: true,
+                                            delete: true,
+                                            update: true,
+                                            view: true,
+                                        },
+                                        guest: {
+                                            create: false,
+                                            delete: false,
+                                            update: false,
+                                            view: false,
+                                        },
+                                    },
+                                },
+                                {
+                                    key: 'afed9af4-f48c-4e0c-a22b-9f958161e55d',
+                                    data: {
+                                        nameInternal: 'wmts type',
+                                        attribution: 'wmattr',
+                                        type: 'wmts',
+                                        urls: ['loc1', 'loc2'],
+                                    },
+                                    permissions: {
+                                        activeUser: {
+                                            create: true,
+                                            delete: true,
+                                            update: true,
+                                            view: true,
+                                        },
+                                        guest: {
+                                            create: false,
+                                            delete: false,
+                                            update: false,
+                                            view: false,
+                                        },
+                                    },
+                                },
+                                {
+                                    key: 'cb007139-9b66-4e71-a092-8c779a9a1d90',
+                                    data: {
+                                        nameInternal: 'vector type',
+                                        attribution: 'vattr',
+                                        type: 'vector',
+                                        layerName: 'lv',
+                                        tableName: 'tv',
+                                    },
+                                    permissions: {
+                                        activeUser: {
+                                            create: true,
+                                            delete: true,
+                                            update: true,
+                                            view: true,
+                                        },
+                                        guest: {
+                                            create: false,
+                                            delete: false,
+                                            update: false,
+                                            view: false,
+                                        },
+                                    },
+                                },
+                                {
+                                    key: 'db60a6f7-6a35-4bcb-af9a-24b8149f7bc5',
+                                    data: {
+                                        nameInternal: 'wms type',
+                                        attribution: 'wattr',
+                                        type: 'wms',
+                                        url: 'localhost',
+                                        layers: 'wms_layers',
+                                        styles: 'wms_styles',
+                                        configuration: {k: 'v'},
+                                    },
+                                    permissions: {
+                                        activeUser: {
+                                            create: true,
+                                            delete: true,
+                                            update: true,
+                                            view: true,
+                                        },
+                                        guest: {
+                                            create: false,
+                                            delete: false,
+                                            update: false,
+                                            view: false,
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                        success: true,
+                        total: 5,
+                        limit: 100,
+                        offset: 0,
+                        changes: {},
+                    },
+                },
+            },
+        ];
+
+        tests.forEach((test) => {
+            it(test.name, async function () {
+                const response = await fetch(
+                    url('/rest/dataSources/filtered/dataSource'),
+                    {
+                        method: 'POST',
+                        headers: test.headers,
+                        body: test.body,
+                    }
+                );
+
+                assert.strictEqual(response.status, 200);
+
+                const data = await response.json();
+                assert.deepStrictEqual(data, test.expectedResult.body);
+            });
+        });
+    });
+
+    describe('PUT /rest/dataSources', function () {
+        const tests = [
+            {
+                name: 'change attr of null type',
+                headers: new fetch.Headers({
+                    Authorization: createAdminToken(),
+                    'Content-Type': 'application/json',
+                }),
+                body: JSON.stringify({
+                    data: {
+                        dataSource: [
+                            {
+                                key: '1e1d2a18-9c2f-4e4a-8009-dd5cd05a52c8',
+                                data: {
+                                    nameInternal: 'changed name',
+                                },
+                            },
+                        ],
+                    },
+                }),
+                expectedResult: {
+                    body: {
+                        data: {
+                            dataSource: [
+                                {
+                                    key: '1e1d2a18-9c2f-4e4a-8009-dd5cd05a52c8',
+                                    data: {
+                                        nameInternal: 'changed name',
+                                        attribution: 'attr',
+                                        type: null,
+                                    },
+                                    permissions: {
+                                        activeUser: {
+                                            create: true,
+                                            delete: true,
+                                            update: true,
+                                            view: true,
+                                        },
+                                        guest: {
+                                            create: false,
+                                            delete: false,
+                                            update: false,
+                                            view: false,
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                        total: 1,
+                        success: true,
+                    },
+                },
+            },
+            {
+                name: 'change raster attr',
+                headers: new fetch.Headers({
+                    Authorization: createAdminToken(),
+                    'Content-Type': 'application/json',
+                }),
+                body: JSON.stringify({
+                    data: {
+                        dataSource: [
+                            {
+                                key: '44e47b74-fb6c-434a-a678-340fb2c6236a',
+                                data: {
+                                    layerName: 'changed layer',
+                                },
+                            },
+                        ],
+                    },
+                }),
+                expectedResult: {
+                    body: {
+                        data: {
+                            dataSource: [
+                                {
+                                    key: '44e47b74-fb6c-434a-a678-340fb2c6236a',
+                                    data: {
+                                        nameInternal: 'raster type',
+                                        attribution: 'attr',
+                                        type: 'raster',
+                                        layerName: 'changed layer',
+                                        tableName: 'tr',
+                                    },
+                                    permissions: {
+                                        activeUser: {
+                                            create: true,
+                                            delete: true,
+                                            update: true,
+                                            view: true,
+                                        },
+                                        guest: {
+                                            create: false,
+                                            delete: false,
+                                            update: false,
+                                            view: false,
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                        total: 1,
+                        success: true,
+                    },
+                },
+            },
+            {
+                name: 'change wms to wmts',
+                headers: new fetch.Headers({
+                    Authorization: createAdminToken(),
+                    'Content-Type': 'application/json',
+                }),
+                body: JSON.stringify({
+                    data: {
+                        dataSource: [
+                            {
+                                key: 'db60a6f7-6a35-4bcb-af9a-24b8149f7bc5',
+                                data: {
+                                    type: 'wmts',
+                                    urls: ['l1', 'l2'],
+                                },
+                            },
+                        ],
+                    },
+                }),
+                expectedResult: {
+                    body: {
+                        data: {
+                            dataSource: [
+                                {
+                                    key: 'db60a6f7-6a35-4bcb-af9a-24b8149f7bc5',
+                                    data: {
+                                        nameInternal: 'wms type',
+                                        attribution: 'wattr',
+                                        type: 'wmts',
+                                        urls: ['l1', 'l2'],
+                                    },
+                                    permissions: {
+                                        activeUser: {
+                                            create: true,
+                                            delete: true,
+                                            update: true,
+                                            view: true,
+                                        },
+                                        guest: {
+                                            create: false,
+                                            delete: false,
+                                            update: false,
+                                            view: false,
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                        total: 1,
+                        success: true,
+                    },
+                },
+            },
+            {
+                name: 'change wmts to null',
+                headers: new fetch.Headers({
+                    Authorization: createAdminToken(),
+                    'Content-Type': 'application/json',
+                }),
+                body: JSON.stringify({
+                    data: {
+                        dataSource: [
+                            {
+                                key: 'db60a6f7-6a35-4bcb-af9a-24b8149f7bc5',
+                                data: {
+                                    type: null,
+                                },
+                            },
+                        ],
+                    },
+                }),
+                expectedResult: {
+                    body: {
+                        data: {
+                            dataSource: [
+                                {
+                                    key: 'db60a6f7-6a35-4bcb-af9a-24b8149f7bc5',
+                                    data: {
+                                        nameInternal: 'wms type',
+                                        attribution: 'wattr',
+                                        type: null,
+                                    },
+                                    permissions: {
+                                        activeUser: {
+                                            create: true,
+                                            delete: true,
+                                            update: true,
+                                            view: true,
+                                        },
+                                        guest: {
+                                            create: false,
+                                            delete: false,
+                                            update: false,
+                                            view: false,
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                        total: 1,
+                        success: true,
+                    },
+                },
+            },
+        ];
+
+        tests.forEach((test) => {
+            it(test.name, async function () {
+                const response = await fetch(url('/rest/dataSources'), {
+                    method: 'PUT',
+                    headers: test.headers,
+                    body: test.body,
+                });
+
+                assert.strictEqual(response.status, 200);
+
+                const data = await response.json();
+                const sortedData = _.update(
+                    ['data', 'dataSource'],
+                    (ds) => _.sortBy((r) => r.key, ds),
+                    data
+                );
+                assert.deepStrictEqual(sortedData, test.expectedResult.body);
+            });
+        });
+    });
 });

--- a/tests/functional/spatial-test.js
+++ b/tests/functional/spatial-test.js
@@ -36,7 +36,7 @@ describe('/rest/dataSources', function () {
                 }),
                 body: JSON.stringify({
                     data: {
-                        dataSource: [
+                        spatial: [
                             {
                                 key: '1e1d2a18-9c2f-4e4a-8009-dd5cd05a52c8',
                                 data: {
@@ -92,7 +92,7 @@ describe('/rest/dataSources', function () {
                 expectedResult: {
                     body: {
                         data: {
-                            dataSource: [
+                            spatial: [
                                 {
                                     key: '1e1d2a18-9c2f-4e4a-8009-dd5cd05a52c8',
                                     data: {
@@ -233,7 +233,7 @@ describe('/rest/dataSources', function () {
 
                 const data = await response.json();
                 const sortedData = _.update(
-                    ['data', 'dataSource'],
+                    ['data', 'spatial'],
                     (ds) => _.sortBy((r) => r.key, ds),
                     data
                 );
@@ -242,7 +242,7 @@ describe('/rest/dataSources', function () {
         });
     });
 
-    describe('POST ​/rest​/dataSources​/filtered​/dataSource', function () {
+    describe('POST ​/rest​/dataSources​/filtered​/spatial', function () {
         const tests = [
             {
                 name: 'all',
@@ -256,7 +256,7 @@ describe('/rest/dataSources', function () {
                 expectedResult: {
                     body: {
                         data: {
-                            dataSource: [
+                            spatial: [
                                 {
                                     key: '1e1d2a18-9c2f-4e4a-8009-dd5cd05a52c8',
                                     data: {
@@ -399,7 +399,7 @@ describe('/rest/dataSources', function () {
                 expectedResult: {
                     body: {
                         data: {
-                            dataSource: [
+                            spatial: [
                                 {
                                     key: '44e47b74-fb6c-434a-a678-340fb2c6236a',
                                     data: {
@@ -447,7 +447,7 @@ describe('/rest/dataSources', function () {
                 expectedResult: {
                     body: {
                         data: {
-                            dataSource: [
+                            spatial: [
                                 {
                                     key: '44e47b74-fb6c-434a-a678-340fb2c6236a',
                                     data: {
@@ -487,7 +487,7 @@ describe('/rest/dataSources', function () {
         tests.forEach((test) => {
             it(test.name, async function () {
                 const response = await fetch(
-                    url('/rest/dataSources/filtered/dataSource'),
+                    url('/rest/dataSources/filtered/spatial'),
                     {
                         method: 'POST',
                         headers: test.headers,
@@ -513,7 +513,7 @@ describe('/rest/dataSources', function () {
                 }),
                 body: JSON.stringify({
                     data: {
-                        dataSource: [
+                        spatial: [
                             {
                                 key: '1e1d2a18-9c2f-4e4a-8009-dd5cd05a52c8',
                                 data: {
@@ -526,7 +526,7 @@ describe('/rest/dataSources', function () {
                 expectedResult: {
                     body: {
                         data: {
-                            dataSource: [
+                            spatial: [
                                 {
                                     key: '1e1d2a18-9c2f-4e4a-8009-dd5cd05a52c8',
                                     data: {
@@ -564,7 +564,7 @@ describe('/rest/dataSources', function () {
                 }),
                 body: JSON.stringify({
                     data: {
-                        dataSource: [
+                        spatial: [
                             {
                                 key: '44e47b74-fb6c-434a-a678-340fb2c6236a',
                                 data: {
@@ -577,7 +577,7 @@ describe('/rest/dataSources', function () {
                 expectedResult: {
                     body: {
                         data: {
-                            dataSource: [
+                            spatial: [
                                 {
                                     key: '44e47b74-fb6c-434a-a678-340fb2c6236a',
                                     data: {
@@ -617,7 +617,7 @@ describe('/rest/dataSources', function () {
                 }),
                 body: JSON.stringify({
                     data: {
-                        dataSource: [
+                        spatial: [
                             {
                                 key: 'db60a6f7-6a35-4bcb-af9a-24b8149f7bc5',
                                 data: {
@@ -631,7 +631,7 @@ describe('/rest/dataSources', function () {
                 expectedResult: {
                     body: {
                         data: {
-                            dataSource: [
+                            spatial: [
                                 {
                                     key: 'db60a6f7-6a35-4bcb-af9a-24b8149f7bc5',
                                     data: {
@@ -670,7 +670,7 @@ describe('/rest/dataSources', function () {
                 }),
                 body: JSON.stringify({
                     data: {
-                        dataSource: [
+                        spatial: [
                             {
                                 key: 'db60a6f7-6a35-4bcb-af9a-24b8149f7bc5',
                                 data: {
@@ -683,7 +683,7 @@ describe('/rest/dataSources', function () {
                 expectedResult: {
                     body: {
                         data: {
-                            dataSource: [
+                            spatial: [
                                 {
                                     key: 'db60a6f7-6a35-4bcb-af9a-24b8149f7bc5',
                                     data: {
@@ -727,7 +727,7 @@ describe('/rest/dataSources', function () {
 
                 const data = await response.json();
                 const sortedData = _.update(
-                    ['data', 'dataSource'],
+                    ['data', 'spatial'],
                     (ds) => _.sortBy((r) => r.key, ds),
                     data
                 );
@@ -760,7 +760,7 @@ describe('/rest/dataSources', function () {
                 }),
                 body: JSON.stringify({
                     data: {
-                        dataSource: [
+                        spatial: [
                             {
                                 key: 'db60a6f7-6a35-4bcb-af9a-24b8149f7bc5',
                             },
@@ -806,7 +806,7 @@ describe('/rest/dataSources', function () {
                 }),
                 body: JSON.stringify({
                     data: {
-                        dataSource: [
+                        spatial: [
                             {
                                 key: '44e47b74-fb6c-434a-a678-340fb2c6236a',
                             },


### PR DESCRIPTION
It seems that changes are currently only tracked for these tables: https://github.com/gisat-panther/be-core/blob/cfbe1aa75d3b984a6a1f8d1e8e579eb5b4bc288a/migrations/202006181232.do.sql#L1

should I create another pr with tracking changes from all other tables that are currently available via api (can be seen in swagger: http://localhost:9850/#/)

todo:
- [x] dependent column filters